### PR TITLE
Use wagtail_hooks mechanism to inject editor JS/CSS

### DIFF
--- a/wagtailmarkdown/wagtail_hooks.py
+++ b/wagtailmarkdown/wagtail_hooks.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from wagtail.wagtailcore import hooks
+
+
+@hooks.register('insert_editor_js')
+def editor_js():
+    s = """<script src="{0}wagtailmarkdown/js/simplemde.min.js"></script>"""
+    s += """<script src="{0}wagtailmarkdown/js/simplemde.attach.js"></script>"""
+    return s.format(settings.STATIC_URL)
+
+
+@hooks.register('insert_editor_css')
+def editor_css():
+    s = """<link rel="stylesheet" href="{0}wagtailmarkdown/css/simplemde.min.css">"""
+    return s.format(settings.STATIC_URL)


### PR DESCRIPTION
Markdown editor doesn't load at least on Wagtail 1.1. Apparently JS and CSS are injected now through a hooks mechanism.

This PR implements the `wagtail_hooks` mechanism.