### PR TITLE
FIX: Wagtail 2 compatibility in `MarkdownPanel`

### DIFF
--- a/wagtailmarkdown/edit_handlers.py
+++ b/wagtailmarkdown/edit_handlers.py
@@ -14,5 +14,4 @@ except ImportError:
 
 
 class MarkdownPanel(FieldPanel):
-    def __init__(self, field_name, classname="", widget=None):
-        super(MarkdownPanel, self).__init__(field_name, classname, widget)
+    pass


### PR DESCRIPTION
Fixes errors:

* "got an unexpected keyword argument 'heading'" — Caused by a new keyword argument in Wagtail 2.
* "got multiple values for argument 'heading'" — Caused by a keyword argument getting converted to a positional argument.