### PR TITLE
Support Wagtail 2.0

### DIFF
--- a/wagtailmarkdown/mdx/linkers/image.py
+++ b/wagtailmarkdown/mdx/linkers/image.py
@@ -9,7 +9,11 @@
 #
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 
-from wagtail.wagtailimages import get_image_model
+try:  # wagtail < 2.0
+    from wagtail.wagtailimages import get_image_model
+except ModuleNotFoundError:  # wagtail >= 2.0
+    from wagtail.images import get_image_model
+
 
 from markdown.util import etree
 


### PR DESCRIPTION
Updates import from Wagtail image module to support the import path for
both Wagtail < 2.0 and Wagtail >= 2.0.

See http://docs.wagtail.io/en/v2.1/releases/2.0.html#wagtail-module-path-updates