### PR TITLE
Support Wagtail 2.0

### DIFF
--- a/wagtailmarkdown/mdx/linkers/image.py
+++ b/wagtailmarkdown/mdx/linkers/image.py
@@ -9,9 +9,13 @@
 #
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 
-from wagtail.wagtailimages import get_image_model
-
 from markdown.util import etree
+
+try:  # wagtail < 2.0
+    from wagtail.wagtailimages import get_image_model
+except ModuleNotFoundError:  # wagtail >= 2.0
+    from wagtail.images import get_image_model
+
 
 # TODO: Default spec and class should be configurable, because they're
 # dependent on how the project is set up.  Hard-coding of 'left',


### PR DESCRIPTION
Updates import from Wagtail image module to support the import path for
both Wagtail < 2.0 and Wagtail >= 2.0.