### PR TITLE
Allow superscript HTML tags.

### DIFF
--- a/wagtailmarkdown/utils.py
+++ b/wagtailmarkdown/utils.py
@@ -55,6 +55,7 @@ def _get_bleach_kwargs():
         'em',
         'strong',
         'ul',
+        'sup',
         'li',
         'dl',
         'dd',


### PR DESCRIPTION
The footnote processor is enabled by default, but generates subscript tags, which bleach was hitherto configured to escape.