### PR TITLE
Custom extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ class MyPage(Page):
 
 And render the content in a template:
 
-```
+```html+django
 {% load wagtailmarkdown %}
 <article>
 {{ self.body|markdown }}
@@ -78,7 +78,7 @@ And render the content in a template:
 
 You can pass extensions by name to the filter:
 
-```
+```html+django
 {% load wagtailmarkdown %}
 <article>
 {{ self.body|markdown:"my_extension_package.my_extension_module" }}

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ extensions to make it actually useful in Wagtail:
 * Inline Markdown preview using [SimpleMDE](http://nextstepwebs.github.io/simplemde-markdown-editor/)
 
 These are implemented using the `python-markdown` extension interface.
-Currently, adding new extensions isn't possible without modifying the code, but
-that shouldn't be difficult to implement (patches welcome).
 
 ### Installation
 Alpha release is available on Pypi - https://pypi.org/project/wagtail-markdown/ - installable via `pip install wagtail-markdown`. It's not a production ready release.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ And render the content in a template:
 </article>
 ```
 
+You can pass extensions by name to the filter:
+
+```
+{% load wagtailmarkdown %}
+<article>
+{{ self.body|markdown:"my_extension_package.my_extension_module" }}
+</article>
+```
+
 <img src="https://i.imgur.com/Sj1f4Jh.png" width="728px" alt="">
 
 To enable syntax highlighting please use the Pygments (`pip install Pygments`) library.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,24 @@ You can pass extensions by name to the filter:
 </article>
 ```
 
+The markdown filter sanitizes the output of the underlying markdown processor,
+to prevent an untrusted user from passing malicious markup. This may conflict
+with some extensions.  When additional extensions are specified, it is possible
+to specify what additional HTML must be allowed through. This is done by
+defining a module variable `allowed_markup` for extensions specified as
+`"module name"`, or a class variable `allowed_markup` for extensions specified
+as `"module_name:class_name"`. In either case it is possible to recursively add
+to the `bleach` white list for tags, attributes, and styles. For example, adding
+```python
+allowed_markup = {
+  tags : ["sub"],
+  attributes : { img : ["srcset"] },
+  styles : [ "text-decoration-line" ]
+}
+```
+to the extension module allows subscripts, image source sets, and text decoration (such as
+underline or strike through) in addition to the HTML permitted by default.
+
 <img src="https://i.imgur.com/Sj1f4Jh.png" width="728px" alt="">
 
 To enable syntax highlighting please use the Pygments (`pip install Pygments`) library.

--- a/wagtailmarkdown/templatetags/wagtailmarkdown.py
+++ b/wagtailmarkdown/templatetags/wagtailmarkdown.py
@@ -16,5 +16,5 @@ register = template.Library()
 
 
 @register.filter(name='markdown')
-def markdown(value):
-    return render_markdown(value)
+def markdown(value, extensions=''):
+    return render_markdown(value, extensions=extensions)

--- a/wagtailmarkdown/utils.py
+++ b/wagtailmarkdown/utils.py
@@ -19,19 +19,21 @@ from .mdx import linker, tables
 from .warnings import WagtailMarkdownDeprecationWarning
 
 
-def render_markdown(text, context=None):
+def render_markdown(text, context=None, extensions=''):
     """
     Turn markdown into HTML.
     """
     if context is None or not isinstance(context, dict):
         context = {}
-    markdown_html = _transform_markdown_into_html(text)
+    markdown_html = _transform_markdown_into_html(text, extensions)
     sanitised_markdown_html = _sanitise_markdown_html(markdown_html)
     return mark_safe(sanitised_markdown_html)
 
 
-def _transform_markdown_into_html(text):
-    return markdown.markdown(smart_text(text), **_get_markdown_kwargs())
+def _transform_markdown_into_html(text, extensions):
+    markdown_kwargs = _get_markdown_kwargs()
+    markdown_kwargs['extensions'] += extensions.split()
+    return markdown.markdown(smart_text(text), **markdown_kwargs)
 
 
 def _sanitise_markdown_html(markdown_html):

--- a/wagtailmarkdown/utils.py
+++ b/wagtailmarkdown/utils.py
@@ -27,7 +27,8 @@ def render_markdown(text, context=None, extensions=''):
     if context is None or not isinstance(context, dict):
         context = {}
     markdown_html = _transform_markdown_into_html(text, extensions)
-    sanitised_markdown_html = _sanitise_markdown_html(markdown_html, extensions)
+    sanitised_markdown_html = _sanitise_markdown_html(markdown_html,
+                                                      extensions)
     return mark_safe(sanitised_markdown_html)
 
 
@@ -41,7 +42,8 @@ def _sanitise_markdown_html(markdown_html, extensions):
     """Ask the extensions in the string extensions what extra markup they allow
        and combine with default keyword arguments to bleach.clean.
 
-       Note that we only process the 'tags', 'attributes', and 'styles' keywords.
+       Note that we only process the 'tags', 'attributes', and 'styles'
+       keywords.
     """
     bleach_kwargs = _get_base_bleach_kwargs()
     for extension_name in extensions.split():
@@ -64,10 +66,11 @@ def _sanitise_markdown_html(markdown_html, extensions):
 
 
 def _get_extension_bleach_kwargs(extension_name):
-    """Use the lookup algorithm for python-markdown to find an extension class or module.
+    """Use the lookup algorithm for python-markdown to find an extension
+       class or module.
 
-       If the extension specifier gives a class (is 'module:classname') we look
-       for class variable 'allowed_markup'.
+       If the extension specifier gives a class (is 'module:classname') we
+       look for class variable 'allowed_markup'.
        If the extension specifier if a module we look for a module level
        variable 'allowed_markup'.
        In each case the result is a dictionary of keyword args that will be
@@ -88,12 +91,13 @@ def _get_extension_bleach_kwargs(extension_name):
     except ImportError:
         return {}
     try:
-      if class_name:
+        if class_name:
             return getattr(module, class_name).allowed_markup
-      else:
+        else:
             return module.allowed_markup
     except AttributeError:
         return {}
+
 
 def _get_base_bleach_kwargs():
     bleach_kwargs = {}

--- a/wagtailmarkdown/utils.py
+++ b/wagtailmarkdown/utils.py
@@ -7,6 +7,7 @@
 # freely. This software is provided 'as-is', without any express or implied
 # warranty.
 #
+import importlib
 import warnings
 
 from django.utils.encoding import smart_text
@@ -26,7 +27,7 @@ def render_markdown(text, context=None, extensions=''):
     if context is None or not isinstance(context, dict):
         context = {}
     markdown_html = _transform_markdown_into_html(text, extensions)
-    sanitised_markdown_html = _sanitise_markdown_html(markdown_html)
+    sanitised_markdown_html = _sanitise_markdown_html(markdown_html, extensions)
     return mark_safe(sanitised_markdown_html)
 
 
@@ -36,11 +37,65 @@ def _transform_markdown_into_html(text, extensions):
     return markdown.markdown(smart_text(text), **markdown_kwargs)
 
 
-def _sanitise_markdown_html(markdown_html):
-    return bleach.clean(markdown_html, **_get_bleach_kwargs())
+def _sanitise_markdown_html(markdown_html, extensions):
+    """Ask the extensions in the string extensions what extra markup they allow
+       and combine with default keyword arguments to bleach.clean.
+
+       Note that we only process the 'tags', 'attributes', and 'styles' keywords.
+    """
+    bleach_kwargs = _get_base_bleach_kwargs()
+    for extension_name in extensions.split():
+        extra = _get_extension_bleach_kwargs(extension_name)
+        if "tags" in extra:
+            for tag in extra["tags"]:
+                if tag not in bleach_kwargs["tags"]:
+                    bleach_kwargs["tags"].append(tag)
+        if "attributes" in extra:
+            for tag, attrs in extra["attributes"].items():
+                for att in attrs:
+                    if att not in bleach_kwargs["attributes"][tag]:
+                        bleach_kwargs["attributes"][tag].append(att)
+        if "styles" in extra:
+            for style in extra["styles"]:
+                if style not in bleach_kwargs["styles"]:
+                    bleach_kwargs["styles"].append(style)
+
+    return bleach.clean(markdown_html, **bleach_kwargs)
 
 
-def _get_bleach_kwargs():
+def _get_extension_bleach_kwargs(extension_name):
+    """Use the lookup algorithm for python-markdown to find an extension class or module.
+
+       If the extension specifier gives a class (is 'module:classname') we look
+       for class variable 'allowed_markup'.
+       If the extension specifier if a module we look for a module level
+       variable 'allowed_markup'.
+       In each case the result is a dictionary of keyword args that will be
+       recursively merged with the defaults (see the calling function,
+       _sanitize_markdown_html).
+
+       If allowed_markup is not found return {}.
+
+       We do not currently recognize either deprrecated or version 2+ only
+       syntax for specifying extensions.
+    """
+    # Get class name (if provided): `path.to.module:ClassName`
+    ext_name, class_name = extension_name.split(':', 1) \
+        if ':' in extension_name else (extension_name, '')
+
+    try:
+        module = importlib.import_module(ext_name)
+    except ImportError:
+        return {}
+    try:
+      if class_name:
+            return getattr(module, class_name).allowed_markup
+      else:
+            return module.allowed_markup
+    except AttributeError:
+        return {}
+
+def _get_base_bleach_kwargs():
     bleach_kwargs = {}
     bleach_kwargs['tags'] = [
         'p',


### PR DESCRIPTION
Short patch to allow template users to specify additional extensions by name, as long as the markup they generate is already acceptable by the sanitation process.