### PR TITLE
Set tab_length to 2 for sane list formatting

### DIFF
--- a/wagtailmarkdown/utils.py
+++ b/wagtailmarkdown/utils.py
@@ -149,6 +149,7 @@ def _get_markdown_kwargs():
         ]
     }
     markdown_kwargs['output_format'] = 'html5'
+    markdown_kwargs['tab_length'] = 2
     return markdown_kwargs
 
 


### PR DESCRIPTION
Allows to create nested lists by two spaces.

- item
  - subitem
  - subitem2
- item2

https://github.com/Python-Markdown/markdown/issues/3#issuecomment-1624529