### PR TITLE
Add setting to customize extension options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Lists](https://python-markdown.github.io/extensions/sane_lists/) extensions:
 WAGTAILMARKDOWN_EXTENSIONS = ["toc", "sane_lists"]
 ```
 
+You can also configure specific extensions using the `WAGTAILMARKDOWN_EXTENSION_CONFIGS` setting.
+
+For example, to customize the settings for the `codehilite` extension, you can do something like this:
+
+```python
+WAGTAILMARKDOWN_EXTENSION_CONFIGS = {
+    "codehilite": [("guess_lang", True), ("linenums", True)]
+}
+```
+
 ### Installation
 Alpha release is available on Pypi - https://pypi.org/project/wagtail-markdown/ - installable via `pip install wagtail-markdown`. It's not a production ready release.
 

--- a/wagtailmarkdown/utils.py
+++ b/wagtailmarkdown/utils.py
@@ -162,7 +162,7 @@ def _get_markdown_kwargs():
         ) in settings.WAGTAILMARKDOWN_EXTENSION_CONFIGS.items():
             conf[extension_name] = options
             # Copy over defaut options that aren't overwritten
-            for opt in markdown_kwargs["extension_configs"][extension_config]:
+            for opt in markdown_kwargs["extension_configs"][extension_name]:
                 if opt[0] not in [new_opt[0] for new_opt in options]:
                     conf[extension_name].append(opt)
                     

--- a/wagtailmarkdown/utils.py
+++ b/wagtailmarkdown/utils.py
@@ -162,11 +162,13 @@ def _get_markdown_kwargs():
         ) in settings.WAGTAILMARKDOWN_EXTENSION_CONFIGS.items():
             conf[extension_name] = options
             # Copy over defaut options that aren't overwritten
-            for opt in markdown_kwargs["extension_configs"][extension_name]:
-                if opt[0] not in [new_opt[0] for new_opt in options]:
-                    conf[extension_name].append(opt)
-                    
-        markdown_kwargs['extension_configs'] = conf
+            default_opts = markdown_kwargs["extension_configs"][extension_name]
+            if default_opts:
+                for opt in default_opts:
+                    if opt[0] not in [new_opt[0] for new_opt in options]:
+                        conf[extension_name].append(opt)
+
+        markdown_kwargs["extension_configs"] = conf
 
     markdown_kwargs['output_format'] = 'html5'
     return markdown_kwargs

--- a/wagtailmarkdown/utils.py
+++ b/wagtailmarkdown/utils.py
@@ -153,6 +153,19 @@ def _get_markdown_kwargs():
             ('guess_lang', False),
         ]
     }
+
+    if hasattr(settings, "WAGTAILMARKDOWN_EXTENSION_CONFIGS"):
+        conf = {}
+        for (
+            extension_name,
+            options,
+        ) in settings.WAGTAILMARKDOWN_EXTENSION_CONFIGS.items():
+            conf[extension_name] = options
+            # Copy over defaut options that aren't overwritten
+            for opt in markdown_kwargs["extension_configs"][extension_config]:
+                if opt[0] not in [new_opt[0] for new_opt in options]:
+                    conf[extension_name].append(opt)
+
     markdown_kwargs['output_format'] = 'html5'
     return markdown_kwargs
 

--- a/wagtailmarkdown/utils.py
+++ b/wagtailmarkdown/utils.py
@@ -165,6 +165,8 @@ def _get_markdown_kwargs():
             for opt in markdown_kwargs["extension_configs"][extension_config]:
                 if opt[0] not in [new_opt[0] for new_opt in options]:
                     conf[extension_name].append(opt)
+                    
+        markdown_kwargs['extension_configs'] = conf
 
     markdown_kwargs['output_format'] = 'html5'
     return markdown_kwargs


### PR DESCRIPTION
This pull request adds an additional setting that allows users to customize extension options.

For example:

```python
WAGTAILMARKDOWN_EXTENSION_CONFIGS = {
    "codehilite": [("guess_lang", True), ("linenums", True)]
}
```