### PR TITLE
Wagtail 2.13 compatibility

### DIFF
--- a/wagtailmarkdown/blocks.py
+++ b/wagtailmarkdown/blocks.py
@@ -8,6 +8,7 @@
 # warranty.
 #
 from django import forms
+from django.utils.functional import cached_property
 
 from .utils import render_markdown
 from .widgets import MarkdownTextarea
@@ -19,11 +20,11 @@ except ImportError:
 
 
 class MarkdownBlock(TextBlock):
-    def __init__(self, required=True, help_text=None, **kwargs):
-        self.field = forms.CharField(
-            required=required, help_text=help_text, widget=MarkdownTextarea()
-        )
-        super(MarkdownBlock, self).__init__(**kwargs)
+    @cached_property
+    def field(self):
+        field_kwargs = {"widget": MarkdownTextarea(attrs={"rows": self.rows})}
+        field_kwargs.update(self.field_options)
+        return forms.CharField(**field_kwargs)
 
     def render_basic(self, value, context=None):
         return render_markdown(value, context)

--- a/wagtailmarkdown/static/wagtailmarkdown/js/easymde.attach.js
+++ b/wagtailmarkdown/static/wagtailmarkdown/js/easymde.attach.js
@@ -20,6 +20,9 @@ function easymdeAttach(id, autoDownloadFontAwesome) {
     });
     mde.render();
 
+    // Save the codemirror instance on the original html element for later use.
+    mde.element.codemirror = mde.codemirror;
+
     mde.codemirror.on("change", function(){
         $('#' + id).val(mde.value());
     });
@@ -29,20 +32,20 @@ function easymdeAttach(id, autoDownloadFontAwesome) {
 * Used to initialize Simple MDE when MarkdownFields are used on a page.
 */
 $(document).ready(function() {
-$(".object.markdown textarea").each(function(index, elem) {
-    easymdeAttach(elem.id);
-});
+    $(".object.markdown textarea").each(function(index, elem) {
+        easymdeAttach(elem.id);
+    });
 });
 
 /*
 * Used to initialize content when MarkdownFields are used in admin panels.
 */
 $(document).on('shown.bs.tab', function(e) {
-$('.CodeMirror').each(function(i, el){
-    setTimeout(
-        function() {
-            el.CodeMirror.refresh();
-        }, 100
-    );
-});
+    $('.CodeMirror').each(function(i, el){
+        setTimeout(
+            function() {
+                el.CodeMirror.refresh();
+            }, 100
+        );
+    });
 });

--- a/wagtailmarkdown/static/wagtailmarkdown/js/markdown-textarea-adapter.js
+++ b/wagtailmarkdown/static/wagtailmarkdown/js/markdown-textarea-adapter.js
@@ -14,6 +14,7 @@
         // define public API functions for the widget:
         // https://docs.wagtail.io/en/latest/reference/streamfield/widget_api.html
         return {
+            idForLabel: null,
             getValue: function() {
                 return element.value;
             },

--- a/wagtailmarkdown/static/wagtailmarkdown/js/markdown-textarea-adapter.js
+++ b/wagtailmarkdown/static/wagtailmarkdown/js/markdown-textarea-adapter.js
@@ -1,0 +1,44 @@
+(function() {
+    function MarkdownTextarea(html, config) {
+        this.html = html;
+        this.baseConfig = config;
+    }
+    MarkdownTextarea.prototype.render = function(placeholder, name, id, initialState) {
+        placeholder.outerHTML = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
+
+        var element = document.getElementById(id);
+        element.value = initialState;
+
+        easymdeAttach(id);
+
+        // define public API functions for the widget:
+        // https://docs.wagtail.io/en/latest/reference/streamfield/widget_api.html
+        return {
+            getValue: function() {
+                return element.value;
+            },
+            getState: function() {
+                return element.value;
+            },
+            setState: function() {
+                throw new Error('MarkdownTextarea.setState is not implemented');
+            },
+            getTextLabel: function(opts) {
+                if (!element.value) return '';
+                var maxLength = opts && opts.maxLength,
+                    result = element.value;
+                if (maxLength && result.length > maxLength) {
+                    return result.substring(0, maxLength - 1) + '…';
+                }
+                return result;
+            },
+            focus: function() {
+                setTimeout(function() {
+                    element.codemirror.focus();
+                }, 50);
+            },
+        };
+    };
+
+    window.telepath.register('wagtailmarkdown.widgets.MarkdownTextarea', MarkdownTextarea);
+})();

--- a/wagtailmarkdown/widgets.py
+++ b/wagtailmarkdown/widgets.py
@@ -12,11 +12,19 @@ from django.conf import settings
 
 from wagtail.utils.widgets import WidgetWithScript
 
+try:
+    from wagtail.core.telepath import register
+    from wagtail.core.widget_adapters import WidgetAdapter
+except ImportError:  # do-nothing fallback for Wagtail <2.13
+
+    def register(adapter, cls):
+        pass
+
+    class WidgetAdapter:
+        pass
+
 
 class MarkdownTextarea(WidgetWithScript, forms.widgets.Textarea):
-    def __init__(self, **kwargs):
-        super(MarkdownTextarea, self).__init__(**kwargs)
-
     def render_js_init(self, id_, name, value):
         autodownload_fontawesome = getattr(
             settings, "WAGTAILMARKDOWN_AUTODOWNLOAD_FONTAWESOME", None
@@ -40,3 +48,13 @@ class MarkdownTextarea(WidgetWithScript, forms.widgets.Textarea):
                 "wagtailmarkdown/js/easymde.attach.js",
             ),
         )
+
+
+class MarkdownTextareaAdapter(WidgetAdapter):
+    js_constructor = "wagtailmarkdown.widgets.MarkdownTextarea"
+
+    class Media:
+        js = ["wagtailmarkdown/js/markdown-textarea-adapter.js"]
+
+
+register(MarkdownTextareaAdapter(), MarkdownTextarea)


### PR DESCRIPTION
Fixes #79

Adds a new MarkdownTextarea adapter that takes care of the magic. Wagtail 2.13 now uses the [telepath](https://wagtail.github.io/telepath/) library to map data between the widget and the StreamField representation. More at 
https://docs.wagtail.io/en/latest/reference/streamfield/widget_api.html