### PR TITLE
Fix etree deprecation warnings

### DIFF
--- a/wagtailmarkdown/mdx/tables/__init__.py
+++ b/wagtailmarkdown/mdx/tables/__init__.py
@@ -14,9 +14,10 @@ A simple example:
 Copyright 2009 - [Waylan Limberg](http://achinghead.com)
 """
 
+import xml.etree.ElementTree as etree
+
 from markdown import Extension
 from markdown.blockprocessors import BlockProcessor
-from markdown.util import etree
 
 
 class TableProcessor(BlockProcessor):

--- a/wagtailmarkdown/mdx/tables/__init__.py
+++ b/wagtailmarkdown/mdx/tables/__init__.py
@@ -16,7 +16,7 @@ Copyright 2009 - [Waylan Limberg](http://achinghead.com)
 
 import markdown
 
-if markdown.VERSION >= (3, 2):
+if markdown.version >= (3, 2):
     import xml.etree.ElementTree as etree
 else:
     from markdown.util import etree

--- a/wagtailmarkdown/mdx/tables/__init__.py
+++ b/wagtailmarkdown/mdx/tables/__init__.py
@@ -14,11 +14,15 @@ A simple example:
 Copyright 2009 - [Waylan Limberg](http://achinghead.com)
 """
 
-import markdown
 
-if markdown.version >= (3, 2):
+import markdown
+from packaging.version import Version
+
+if Version(markdown.__version__) >= Version("3.2"):
+    # Using markdown version 3.2+
     import xml.etree.ElementTree as etree
 else:
+    # Using markdown below 3.2
     from markdown.util import etree
 
 from markdown import Extension

--- a/wagtailmarkdown/mdx/tables/__init__.py
+++ b/wagtailmarkdown/mdx/tables/__init__.py
@@ -14,7 +14,12 @@ A simple example:
 Copyright 2009 - [Waylan Limberg](http://achinghead.com)
 """
 
-import xml.etree.ElementTree as etree
+import markdown
+
+if markdown.VERSION >= (3, 2):
+    import xml.etree.ElementTree as etree
+else:
+    from markdown.util import etree
 
 from markdown import Extension
 from markdown.blockprocessors import BlockProcessor


### PR DESCRIPTION
I have changed the import for etree to avoid the Django deprecation warnings