### PR TITLE
Add option to pass additional EasyMDE options

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,28 @@ picked up on pages rendering the relevant output, e.g. your base template:
 <link rel="stylesheet" type="text/css" href="{% static 'path/to/pygments.css' %}">
 ```
 
+#### EasyMDE configuration
+
+EasyMDE options, as specified in [EasyMDE' documentation](https://github.com/Ionaru/easy-markdown-editor#configuration) can be set to configure the inline Markdown editor. To do this, create a static js file, where the options can be set:
+
+```js
+window.wagtailMarkdown = {};
+window.wagtailMarkdown.options = {
+    spellChecker: false,
+}
+```
+
+To make sure that the JS is executed, create a hook in `app_name/wagtail_hooks.py`:
+
+```python
+@hooks.register("insert_global_admin_js", order=100)
+def global_admin_js():
+    """Add /static/js/admin/easymde_custom.js to the admin."""
+    return format_html(
+        '<script src="{}"></script>',
+        static("/js/admin/easymde_custom.js")
+    )
+```
 
 ### Usage
 

--- a/src/wagtailmarkdown/static/wagtailmarkdown/js/easymde.attach.js
+++ b/src/wagtailmarkdown/static/wagtailmarkdown/js/easymde.attach.js
@@ -10,22 +10,22 @@
  */
 
 /*
- * Define globalThis.additionalEasyMDEOptions in your custom code to define options.
+ * Define window.wagtailMarkdown.options in your custom code to set EasyMDE options.
  */
-if (!globalThis.additionalEasyMDEOptions) {
-    globalThis.additionalEasyMDEOptions = {};
+if (!window.wagtailMarkdown || !window.wagtailMarkdown.options) {
+    window.wagtailMarkdown = {options: {}};
 }
 
 /*
  * Used to initialize Simple MDE when Markdown blocks are used in StreamFields
  */
 function easymdeAttach(id, autoDownloadFontAwesome) {
-    Object.assign(globalThis.additionalEasyMDEOptions, {
+    Object.assign(window.wagtailMarkdown.options, {
         element: document.getElementById(id),
         autofocus: false,
         autoDownloadFontAwesome: autoDownloadFontAwesome,
     })
-    var mde = new EasyMDE(globalThis.additionalEasyMDEOptions);
+    var mde = new EasyMDE(window.wagtailMarkdown.options);
     mde.render();
 
     // Save the codemirror instance on the original html element for later use.

--- a/src/wagtailmarkdown/static/wagtailmarkdown/js/easymde.attach.js
+++ b/src/wagtailmarkdown/static/wagtailmarkdown/js/easymde.attach.js
@@ -10,14 +10,22 @@
  */
 
 /*
+ * Define globalThis.additionalEasyMDEOptions in your custom code to define options.
+ */
+if (!globalThis.additionalEasyMDEOptions) {
+    globalThis.additionalEasyMDEOptions = {};
+}
+
+/*
  * Used to initialize Simple MDE when Markdown blocks are used in StreamFields
  */
 function easymdeAttach(id, autoDownloadFontAwesome) {
-    var mde = new EasyMDE({
+    Object.assign(globalThis.additionalEasyMDEOptions, {
         element: document.getElementById(id),
         autofocus: false,
         autoDownloadFontAwesome: autoDownloadFontAwesome,
-    });
+    })
+    var mde = new EasyMDE(globalThis.additionalEasyMDEOptions);
     mde.render();
 
     // Save the codemirror instance on the original html element for later use.


### PR DESCRIPTION
Concerning #64.

This is a very simple approach. You just define the easyMDE object in a static js file that is loaded in your backend and can supply options there. For our case this, is crucial since we also define functions, thus JSON would not suffice.

file: project/static/js/admin/easymde_custom.js
```js
globalThis.additionalEasyMDEOptions = {
    spellChecker: false
}
```

This file just needs to be added to `wagtail_hooks.py`:

```py
@hooks.register("insert_global_admin_js", order=100)
def global_admin_js():
    """Add /static/js/admin/easymde_custom.js to the admin."""
    return format_html(
        '<script src="{}"></script>',
        static("/js/admin/easymde_custom.js")
    )
```
