### PR TITLE
Allow customizing tab_length

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ WAGTAILMARKDOWN = {
     "extensions": [],  # optional. a list of python-markdown supported extensions
     "extension_configs": {},  # optional. a dictionary with the extension name as key, and its configuration as value
     "extensions_settings_mode": "extend",  # optional. Possible values: "extend" or "override". Defaults to "extend".
-    "tab_length": 4,  # optional. Sets the tab_length used by python-markdown. Defaults to 4.
+    "tab_length": 4,  # optional. Sets the length of tabs used by python-markdown to render the out. This is the number of spaces used to replace with a tab character. Defaults to 4.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ WAGTAILMARKDOWN = {
     "extensions": [],  # optional. a list of python-markdown supported extensions
     "extension_configs": {},  # optional. a dictionary with the extension name as key, and its configuration as value
     "extensions_settings_mode": "extend",  # optional. Possible values: "extend" or "override". Defaults to "extend".
+    "tab_length": 4,  # optional. Sets the tab_length used by python-markdown. Defaults to 4.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ WAGTAILMARKDOWN = {
     "extensions": [],  # optional. a list of python-markdown supported extensions
     "extension_configs": {},  # optional. a dictionary with the extension name as key, and its configuration as value
     "extensions_settings_mode": "extend",  # optional. Possible values: "extend" or "override". Defaults to "extend".
-    "tab_length": 4,  # optional. Sets the length of tabs used by python-markdown to render the out. This is the number of spaces used to replace with a tab character. Defaults to 4.
+    "tab_length": 4,  # optional. Sets the length of tabs used by python-markdown to render the output. This is the number of spaces used to replace with a tab character. Defaults to 4.
 }
 ```
 

--- a/src/wagtailmarkdown/utils.py
+++ b/src/wagtailmarkdown/utils.py
@@ -128,7 +128,7 @@ def _get_markdown_kwargs():
         else:
             kwargs["extension_configs"].update(markdown_settings["extension_configs"])
 
-    if 'tab_length' in markdown_settings:
-        kwargs['tab_length'] = markdown_settings['tab_length']
+    if "tab_length" in markdown_settings:
+        kwargs["tab_length"] = markdown_settings["tab_length"]
 
     return kwargs

--- a/src/wagtailmarkdown/utils.py
+++ b/src/wagtailmarkdown/utils.py
@@ -128,4 +128,7 @@ def _get_markdown_kwargs():
         else:
             kwargs["extension_configs"].update(markdown_settings["extension_configs"])
 
+    if 'tab_length' in markdown_settings:
+        kwargs['tab_length'] = markdown_settings['tab_length']
+
     return kwargs

--- a/tests/testapp/tests/test_settings.py
+++ b/tests/testapp/tests/test_settings.py
@@ -53,6 +53,11 @@ class TestSettings(TestCase):
                 kwargs["extension_configs"]["codehilite"], [("guess_lang", True)]
             )
 
+        with override_settings(WAGTAILMARKDOWN={"tab_length": 2}):
+            kwargs = _get_markdown_kwargs()
+            self.assertTrue("tab_length" in kwargs)
+            self.assertTrue(kwargs["tab_length"], 2)
+
         with override_settings(WAGTAILMARKDOWN={"extensions": ["toc"]}):
             kwargs = _get_markdown_kwargs()
             self.assertTrue("toc" in kwargs["extensions"])


### PR DESCRIPTION
The behavior of using four-space indent for nesting can be confusing to some users. This PR allows users to customize the tab_length.