### PR TITLE
Fix double `MarkdownBlock` EasyMDE initialisation

### DIFF
--- a/src/wagtailmarkdown/static/wagtailmarkdown/js/easymde-controller.js
+++ b/src/wagtailmarkdown/static/wagtailmarkdown/js/easymde-controller.js
@@ -1,12 +1,11 @@
-// wagtailmarkdown/static/wagtailmarkdown/js/easymde-controller.js
-
 class EasyMDEContainer extends window.StimulusModule.Controller {
-    static values = { autodownload: Boolean };
+    static values = { autodownload: Boolean};
 
     connect() {
-        if (this.autodownloadValue != null) {
+        if (this.hasAutodownloadValue) {
             easymdeAttach(this.element.id, this.autodownloadValue);
-        } else {
+        }
+        else {
             easymdeAttach(this.element.id);
         }
     }

--- a/src/wagtailmarkdown/static/wagtailmarkdown/js/easymde.attach.js
+++ b/src/wagtailmarkdown/static/wagtailmarkdown/js/easymde.attach.js
@@ -22,7 +22,7 @@ function easymdeAttach(id, autoDownloadFontAwesome) {
     Object.assign(window.wagtailMarkdown.options, {
         element: document.getElementById(id),
         autofocus: false,
-        autoDownloadFontAwesome: autoDownloadFontAwesome !== null ? Boolean(autoDownloadFontAwesome) : null,
+        autoDownloadFontAwesome: autoDownloadFontAwesome,
     })
     var mde = new EasyMDE(window.wagtailMarkdown.options);
     mde.render();

--- a/src/wagtailmarkdown/static/wagtailmarkdown/js/easymde.attach.js
+++ b/src/wagtailmarkdown/static/wagtailmarkdown/js/easymde.attach.js
@@ -39,24 +39,12 @@ function easymdeAttach(id, autoDownloadFontAwesome) {
 /*
 * Used to initialize content when MarkdownFields are used in admin panels.
 */
-function refreshCodeMirror(e) {
-    setTimeout(
-        function() {
-            e.CodeMirror.refresh();
-        }, 100
-    );
-}
-
-// Wagtail < 3.0
-document.addEventListener('shown.bs.tab', function() {
-    document.querySelectorAll('.CodeMirror').forEach(function(e) {
-        refreshCodeMirror(e)
-    });
-});
-
-// Wagtail >= 3.0
 document.addEventListener('wagtail:tab-changed', function() {
     document.querySelectorAll('.CodeMirror').forEach(function(e) {
-        refreshCodeMirror(e)
+        setTimeout(
+            function() {
+                e.CodeMirror.refresh();
+            }, 100
+        );
     });
 });

--- a/src/wagtailmarkdown/widgets.py
+++ b/src/wagtailmarkdown/widgets.py
@@ -2,8 +2,6 @@ from django import forms
 from django.conf import settings
 from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.staticfiles import versioned_static
-from wagtail.telepath import register
-from wagtail.widget_adapters import WidgetAdapter
 
 
 class MarkdownTextareaBase(forms.Textarea):
@@ -48,7 +46,9 @@ if WAGTAIL_VERSION >= (6, 0):
             )
 
 else:
+    from wagtail.telepath import register
     from wagtail.utils.widgets import WidgetWithScript
+    from wagtail.widget_adapters import WidgetAdapter
 
     class MarkdownTextarea(WidgetWithScript, MarkdownTextareaBase):
         def render_js_init(self, id_, name, value):
@@ -62,12 +62,11 @@ else:
 
             return f'easymdeAttach("{id_}");'
 
+    class MarkdownTextareaAdapter(WidgetAdapter):
+        js_constructor = "wagtailmarkdown.widgets.MarkdownTextarea"
 
-class MarkdownTextareaAdapter(WidgetAdapter):
-    js_constructor = "wagtailmarkdown.widgets.MarkdownTextarea"
+        class Media:
+            # TODO: remove the adapter when dropping support for Wagtail 5.2
+            js = ["wagtailmarkdown/js/markdown-textarea-adapter.js"]
 
-    class Media:
-        js = ["wagtailmarkdown/js/markdown-textarea-adapter.js"]
-
-
-register(MarkdownTextareaAdapter(), MarkdownTextarea)
+    register(MarkdownTextareaAdapter(), MarkdownTextarea)

--- a/tests/testapp/tests/test_admin.py
+++ b/tests/testapp/tests/test_admin.py
@@ -43,18 +43,7 @@ class TestFieldsAdmin(TestCase, WagtailTestUtils):
             )
         )
         self.assertContains(response, "easymde.attach.js")
-        if WAGTAIL_VERSION >= (6, 0):
-            self.assertContains(
-                response,
-                "[&quot;markdown&quot;, {&quot;_type&quot;: "
-                "&quot;wagtailmarkdown.widgets.MarkdownTextarea&quot;, "
-                "&quot;_args&quot;: [&quot;&lt;textarea name=\\&quot;__NAME__\\"
-                "&quot; cols=\\&quot;40\\&quot; "
-                "rows=\\&quot;1\\&quot; id=\\&quot;__ID__\\&quot; "
-                "data-controller=\\&quot;easymde\\&quot;&gt;\\n&lt;/textarea&gt;&quot;, "
-                "&quot;__ID__&quot;]}",
-            )
-        else:
+        if WAGTAIL_VERSION < (6, 0):
             self.assertContains(
                 response,
                 "[&quot;markdown&quot;, {&quot;_type&quot;: "
@@ -65,7 +54,7 @@ class TestFieldsAdmin(TestCase, WagtailTestUtils):
                 "&lt;script&gt;easymdeAttach(\\&quot;__ID__\\&quot;);"
                 "&lt;/script&gt;&quot;, &quot;__ID__&quot;]}",
             )
-        self.assertContains(response, "markdown-textarea-adapter.js")
+            self.assertContains(response, "markdown-textarea-adapter.js")
 
     def test_markdown_field(self):
         field = MarkdownField()


### PR DESCRIPTION
Fixes #141

@lb- suggested a conditional

```js
if (!element.matches('[data-controller~="easymde"') {
   // Wagtail 6.0, using data attribute (Stimulus), does not require Telepath to instantiate MD Editor
    easymdeAttach(id);
}
```

in the `wagtailmarkdown/js/markdown-textarea-adapter.js` Telepath adapter, but that is really not needed with the new controller