### PR TITLE
Wagtail 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add Wagtail 6.1 @katdom13
+
+### Removed
+
+- Support for Django < 4.2 @katdom13
+
+
 ## [0.12.1] - 2024-03-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ class MyPage(Page):
     body = MarkdownField()
 
     content_panels = [
-        FieldPanel("title", classname="full title"),
+        FieldPanel("title", classname="title"),
         FieldPanel("body"),
     ]
 ```
@@ -347,11 +347,11 @@ tox -p
 To run tests for a specific environment:
 
 ```shell
-tox -e py312-django5.0-wagtail6.0
+tox -e py312-django5.0-wagtail6.1
 ```
 
 or, a specific test
 
 ```shell
-tox -e py312-django5.0-wagtail6.0 -- tests.testapp.tests.test_admin.TestFieldsAdmin
+tox -e py312-django5.0-wagtail6.1 -- tests.testapp.tests.test_admin.TestFieldsAdmin
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Wagtail",

--- a/tox.ini
+++ b/tox.ini
@@ -60,8 +60,8 @@ base_python = python3.12
 
 ; Note: the following are commented out for development convenience,
 ;       so as to test the interactive mode with a different Wagtail version
-deps =
-    wagtail>=5.2,<6.0
+; deps =
+;     wagtail>=5.2,<6.0
 
 commands_pre =
     python {toxinidir}/tests/manage.py makemigrations --settings=testapp.settings

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 min_version = 4.0
 
 envlist =
-    py{38,39,310}-django3.2-wagtail5.2
-    py{38,39,310,311}-django4.2-wagtail{5.2,6.0}
-    py{311,312}-django5.0-wagtail{5.2,6.0,main}
+    py{38,39,310,311}-django4.2-wagtail{5.2,6.0,6.1,main}
+    py{310,311,312}-django5.0-wagtail{5.2,6.0,6.1,main}
 
 [gh-actions]
 python =
@@ -28,12 +27,12 @@ setenv =
 extras = testing
 
 deps =
-    django3.2: Django>=3.2,<4.0
     django4.2: Django>=4.2,<5.0
     django5.0: Django>=5.0,<5.1
 
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.0: wagtail>=6.0,<6.1
+    wagtail6.1: wagtail>=6.1,<6.2
 
 install_command = python -m pip install -U {opts} {packages}
 commands =
@@ -61,8 +60,8 @@ base_python = python3.12
 
 ; Note: the following are commented out for development convenience,
 ;       so as to test the interactive mode with a different Wagtail version
-; deps =
-;     wagtail>=5.2,<6.0
+deps =
+    wagtail>=5.2,<6.0
 
 commands_pre =
     python {toxinidir}/tests/manage.py makemigrations --settings=testapp.settings


### PR DESCRIPTION
# Notes

- No significant changes related to Wagtail 6.1
- Drop support for Django < 4.2

<details>
<summary>Wagtail 6.1 upgrade check list</summary>

## Code reviewing a consideration.
Use the tick box to indicate a consideration has been code reviewed as OK

### What’s new
  - [ ] [Universal listings continued](https://docs.wagtail.org/en/latest/releases/6.1.html#universal-listings-continued)
  - [ ] [Information-dense admin interface](https://docs.wagtail.org/en/latest/releases/6.1.html#information-dense-admin-interface)
  - [ ] [Custom per-page-type listings](https://docs.wagtail.org/en/latest/releases/6.1.html#custom-per-page-type-listings)
  - [ ] [Keyboard shortcuts overview](https://docs.wagtail.org/en/latest/releases/6.1.html#keyboard-shortcuts-overview)
  - [ ] [Better guidance for password-protected content](https://docs.wagtail.org/en/latest/releases/6.1.html#better-guidance-for-password-protected-content)
  - [ ] [Favicon images generation](https://docs.wagtail.org/en/latest/releases/6.1.html#favicon-images-generation)
  - [ ] [Cve-2024-32882: permission check bypass when editing a model with per-field restrictions through wagtail.contrib.settings or modelviewset](https://docs.wagtail.org/en/latest/releases/6.1.html#cve-2024-32882-permission-check-bypass-when-editing-a-model-with-per-field-restrictions-through-wagtail-contrib-settings-or-modelviewset)
  - [ ] [Other features](https://docs.wagtail.org/en/latest/releases/6.1.html#other-features)
  - [ ] [Bug fixes](https://docs.wagtail.org/en/latest/releases/6.1.html#bug-fixes)
  - [ ] [Documentation](https://docs.wagtail.org/en/latest/releases/6.1.html#documentation)
  - [ ] [Maintenance](https://docs.wagtail.org/en/latest/releases/6.1.html#maintenance)
### Changes affecting wagtail customizations
  - [ ] [Changes to submissionslistview class](https://docs.wagtail.org/en/latest/releases/6.1.html#changes-to-submissionslistview-class)
  - [ ] [Register_user_listing_buttons hook signature changed](https://docs.wagtail.org/en/latest/releases/6.1.html#register-user-listing-buttons-hook-signature-changed)
  - [ ] [Password_required_template has changed to wagtail_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#password-required-template-has-changed-to-wagtail-password-required-template)
  - [ ] [Document_password_required_template has changed to wagtaildocs_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#document-password-required-template-has-changed-to-wagtaildocs-password-required-template)
### Changes to undocumented internals
  - [ ] [Deprecation of user_listing_buttons template tag](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-user-listing-buttons-template-tag)
  - [ ] [Deprecation of wagtailusers_groups:users url pattern](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-wagtailusers-groups-users-url-pattern)
  - [ ] [Deprecation of window.chooserurls within draftail choosers](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers)
  - [ ] [Deprecation of window.initblockwidget to initialize a streamfield block](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-initblockwidget-to-initialize-a-streamfield-block)
  - [ ] [Old](https://docs.wagtail.org/en/latest/releases/6.1.html#id1)
  - [ ] [New](https://docs.wagtail.org/en/latest/releases/6.1.html#id2)
  - [ ] [Removal of jquery from base client-side widget and boundwidget classes](https://docs.wagtail.org/en/latest/releases/6.1.html#removal-of-jquery-from-base-client-side-widget-and-boundwidget-classes)
  - [ ] [Window.urlify deprecated](https://docs.wagtail.org/en/latest/releases/6.1.html#window-urlify-deprecated)
  - [ ] [Window.xregexp polyfill removed](https://docs.wagtail.org/en/latest/releases/6.1.html#window-xregexp-polyfill-removed)

</details>