### PR TITLE
Update for wagtail 6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add Wagtail 6.1 @katdom13
+
+### Removed
+
+- Support for Django < 4.2 @katdom13
+
+
 ## [0.12.1] - 2024-03-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add tox testing for wagtail 6.2
 - Add Wagtail 6.1 @katdom13
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ class MyPage(Page):
     body = MarkdownField()
 
     content_panels = [
-        FieldPanel("title", classname="full title"),
+        FieldPanel("title", classname="title"),
         FieldPanel("body"),
     ]
 ```
@@ -347,11 +347,11 @@ tox -p
 To run tests for a specific environment:
 
 ```shell
-tox -e py312-django5.0-wagtail6.0
+tox -e py312-django5.0-wagtail6.1
 ```
 
 or, a specific test
 
 ```shell
-tox -e py312-django5.0-wagtail6.0 -- tests.testapp.tests.test_admin.TestFieldsAdmin
+tox -e py312-django5.0-wagtail6.1 -- tests.testapp.tests.test_admin.TestFieldsAdmin
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Wagtail",

--- a/tox.ini
+++ b/tox.ini
@@ -60,8 +60,8 @@ base_python = python3.12
 
 ; Note: the following are commented out for development convenience,
 ;       so as to test the interactive mode with a different Wagtail version
-deps =
-    wagtail>=5.2,<6.0
+; deps =
+;     wagtail>=5.2,<6.0
 
 commands_pre =
     python {toxinidir}/tests/manage.py makemigrations --settings=testapp.settings

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 min_version = 4.0
 
 envlist =
-    py{38,39,310}-django3.2-wagtail5.2
-    py{38,39,310,311}-django4.2-wagtail{5.2,6.0}
-    py{311,312}-django5.0-wagtail{5.2,6.0,main}
+    py{38,39,310,311}-django4.2-wagtail{5.2,6.0,6.1,main}
+    py{310,311,312}-django5.0-wagtail{5.2,6.0,6.1,main}
 
 [gh-actions]
 python =
@@ -28,12 +27,12 @@ setenv =
 extras = testing
 
 deps =
-    django3.2: Django>=3.2,<4.0
     django4.2: Django>=4.2,<5.0
     django5.0: Django>=5.0,<5.1
 
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.0: wagtail>=6.0,<6.1
+    wagtail6.1: wagtail>=6.1,<6.2
 
 install_command = python -m pip install -U {opts} {packages}
 commands =
@@ -61,8 +60,8 @@ base_python = python3.12
 
 ; Note: the following are commented out for development convenience,
 ;       so as to test the interactive mode with a different Wagtail version
-; deps =
-;     wagtail>=5.2,<6.0
+deps =
+    wagtail>=5.2,<6.0
 
 commands_pre =
     python {toxinidir}/tests/manage.py makemigrations --settings=testapp.settings

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 min_version = 4.0
 
 envlist =
-    py{38,39,310,311}-django4.2-wagtail{5.2,6.0,6.1,main}
-    py{310,311,312}-django5.0-wagtail{5.2,6.0,6.1,main}
+    py{38,39,310,311}-django4.2-wagtail{5.2,6.0,6.1,6.2,main}
+    py{310,311,312}-django5.0-wagtail{5.2,6.0,6.1,6.2,main}
 
 [gh-actions]
 python =
@@ -33,6 +33,7 @@ deps =
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.0: wagtail>=6.0,<6.1
     wagtail6.1: wagtail>=6.1,<6.2
+    wagtail6.2: wagtail>=6.2,<6.3
 
 install_command = python -m pip install -U {opts} {packages}
 commands =


### PR DESCRIPTION
This builds on: https://github.com/torchbox/wagtail-markdown/pull/144

To add Wagtail 6.2 to the test matrix.