### PR TITLE
Update tox testing for Wagtail 6.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 min_version = 4.22
 
 envlist =
-    py{39,310,311}-dj42-wagtail{52,63}
-    py{310,311}-dj50-wagtail{52,62,63}
-    py{312,313}-dj51-wagtail63
+    py{39,310,311}-dj42-wagtail{52,63,64}
+    py{310,311}-dj50-wagtail{52,62,63,64}
+    py{312,313}-dj51-wagtail{63,64}
 
 [gh-actions]
 python =
@@ -38,6 +38,7 @@ deps =
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5
 
 install_command = python -m pip install -U {opts} {packages}
 commands =


### PR DESCRIPTION
This pull request updates the `tox.ini` file to include support for Wagtail 6.4

Updates to `tox.ini`:

* Added support for Wagtail 6.4 in the `envlist` section.
* Included the dependency specification for Wagtail 6.4 in the `deps` section.