### PR TITLE
Wagtail 7.0 maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add tox testing for wagtail 6.2 and 6.3 and include Django 5.1
 - Update the ruff github action which fixes the error seen in CI
+- Add tox testing for Django 5.2 and Wagtail 6.4, 7.0
+- Support only Wagtail >= 6.3
 
 ## [0.12.1] - 2024-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add tox testing for Django 5.2 and Wagtail 6.4, 7.0
 - Support only Wagtail >= 6.3
 
+- Adds support/testing for Wagtail 6.4 and 7.0, and Django 5.2. It also drops support for Wagtail 5.x and 6.2.
+
 ## [0.12.1] - 2024-03-09
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,17 +21,17 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
 ]
 
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    "Wagtail>=5.2",
+    "Wagtail>=6.3",
     "Markdown>=3.3,<4",
     # note: bleach5 requires bleach[css]. Will make one of the next versions require >= 5
     "bleach>=3.3,<5",

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 min_version = 4.22
 
 envlist =
-    py{39,310,311}-dj42-wagtail{52,63,64}
-    py{310,311}-dj50-wagtail{52,62,63,64}
-    py{312,313}-dj51-wagtail{63,64}
+    py{39,310,311,312}-django42-wagtail{63,64,70}
+    py{310,311,312,313}-django{51,52}-wagtail{63,64,70}
 
 [gh-actions]
 python =
@@ -32,13 +31,12 @@ extras = testing
 
 deps =
     django4.2: Django>=4.2,<5.0
-    django5.0: Django>=5.0,<5.1
     django5.1: Django>=5.1,<5.2
+    django5.2: Django>=5.2,<5.3
 
-    wagtail5.2: wagtail>=5.2,<5.3
-    wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1
 
 install_command = python -m pip install -U {opts} {packages}
 commands =


### PR DESCRIPTION
### Support/Testing for New Versions:
* Added support for Django 5.2 and Wagtail 6.4 and 7.0 

### Dropped Support for Older Framework Versions:
* Removed support for Wagtail 5.x and 6.2 

### Testing Configuration Updates:
* Updated `tox.ini` to reflect new testing environments, adding Django 5.2 and Wagtail 7.0 while removing configurations for older versions like Wagtail 5.2 and 6.2.