### PR TITLE
Strikethrough processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [0.13.0] - 2025-10-06
 
-- Added support and testing for Wagtail 7.1, dropped support for Wagtail 6.4 (EOL) (@damwaingames)
-
-- Add tox testing for wagtail 6.2 and 6.3 and include Django 5.1
-- Update the ruff github action which fixes the error seen in CI
-- Add tox testing for Django 5.2 and Wagtail 6.4, 7.0
-- Support only Wagtail >= 6.3
-
-- Adds support/testing for Wagtail 6.4 and 7.0, and Django 5.2. It also drops support for Wagtail 5.x and 6.2.
+- Added support Wagtail 7.1, Django 5.2 (@damwaingames)
+- Dropped support for Wagtail < 6.3
+- Added custom inline pattern for strikethrough (`~TEXT~` and `--TEXT--`) (@zerolab)
 
 ## [0.12.1] - 2024-03-09
 
@@ -19,7 +14,7 @@
 
 ### Changed
 
-- The telepath adapter code is not longer used in Wagtail 6+
+- The telepath adapter code is no longer used in Wagtail 6+
 
 ## [0.12.0] - 2024-02-29
 
@@ -137,7 +132,8 @@
 - Restructure app, refactor code. Add depreciation warnings.
 
 
-[unreleased]: https://github.com/torchbox/wagtail-markdown/compare/v0.12.1...HEAD
+[unreleased]: https://github.com/torchbox/wagtail-markdown/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/torchbox/wagtail-markdown/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/torchbox/wagtail-markdown/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/torchbox/wagtail-markdown/compare/v0.11.0...v0.12.0
 [0.11.1]: https://github.com/torchbox/wagtail-markdown/compare/v0.11.0...v0.11.1

--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ Previously we supported custom link tags that used the target object title. They
 
 ⚠️ these types of tags are not reliable as titles can and will change. Support for  will be removed in the future.
 
+#### Inline tags
+
+wagtail-markdown supports the following custom inline tags: `~TEXT~` and `~~TEXT~~` for strikethrough. The resulting
+markup is `<del>TEXT</del>`. Note that with this, the default allowed tags include `del` and `ins`.
+
+
 ### Usage
 
 You can use it as a `StreamField` block:
@@ -347,11 +353,11 @@ tox -p
 To run tests for a specific environment:
 
 ```shell
-tox -e py313-django5.1-wagtail6.3
+tox -e py313-django5.2-wagtail7.0
 ```
 
 or, a specific test
 
 ```shell
-tox -e py313-django5.1-wagtail6.3 -- tests.testapp.tests.test_admin.TestFieldsAdmin
+tox -e py313-django5.2-wagtail7.0 -- tests.testapp.tests.test_admin.TestFieldsAdmin
 ```

--- a/src/wagtailmarkdown/__init__.py
+++ b/src/wagtailmarkdown/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 12, 1)
+VERSION = (0, 13, 0)
 __version__ = ".".join(map(str, VERSION))

--- a/src/wagtailmarkdown/constants.py
+++ b/src/wagtailmarkdown/constants.py
@@ -34,6 +34,8 @@ DEFAULT_ALLOWED_TAGS = [
     "ol",
     "hr",
     "br",
+    "del",
+    "ins",
 ]
 
 DEFAULT_ALLOWED_ATTRIBUTES = {

--- a/src/wagtailmarkdown/mdx/inlinepatterns.py
+++ b/src/wagtailmarkdown/mdx/inlinepatterns.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from django.apps import apps
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from markdown import Extension
@@ -6,11 +8,16 @@ from markdown.inlinepatterns import (
     LINK_RE,
     ImageInlineProcessor,
     LinkInlineProcessor,
+    SimpleTagInlineProcessor,
 )
 from wagtail.documents import get_document_model
 from wagtail.images import get_image_model
 from wagtail.images.exceptions import InvalidFilterSpecError
 from wagtail.models import Page
+
+
+if TYPE_CHECKING:
+    from markdown import Markdown
 
 
 def _options_to_dict(value: str) -> dict:
@@ -39,7 +46,7 @@ class ObjectLookupNegotiator:
     MEDIA_PREFIX = "media:"
 
     @staticmethod
-    def retrieve_page(lookup_field_value):
+    def retrieve_page(lookup_field_value) -> Page | None:
         try:
             return Page.objects.get(pk=lookup_field_value)
         except (Page.DoesNotExist, Page.MultipleObjectsReturned):
@@ -131,13 +138,15 @@ class LinkProcessor(LinkInlineProcessor):
 
 
 class ImageExtension(Extension):
-    def __init__(self, object_lookup_negotiator=None, **kwargs):
+    def __init__(
+        self, object_lookup_negotiator: ObjectLookupNegotiator | None = None, **kwargs
+    ):
         self.object_lookup_negotiator = (
             object_lookup_negotiator or ObjectLookupNegotiator
         )
         super().__init__(**kwargs)
 
-    def extendMarkdown(self, md):
+    def extendMarkdown(self, md: "Markdown") -> None:
         md.inlinePatterns.register(
             ImageProcessor(
                 pattern=IMAGE_LINK_RE,
@@ -150,13 +159,15 @@ class ImageExtension(Extension):
 
 
 class LinkExtension(Extension):
-    def __init__(self, object_lookup_negotiator=None, **kwargs):
+    def __init__(
+        self, object_lookup_negotiator: ObjectLookupNegotiator | None = None, **kwargs
+    ):
         self.object_lookup_negotiator = (
             object_lookup_negotiator or ObjectLookupNegotiator
         )
         super().__init__(**kwargs)
 
-    def extendMarkdown(self, md):
+    def extendMarkdown(self, md: "Markdown") -> None:
         md.inlinePatterns.register(
             LinkProcessor(
                 pattern=LINK_RE,
@@ -165,4 +176,12 @@ class LinkExtension(Extension):
             ),
             "link",
             161,
+        )
+
+
+class DelExtension(Extension):
+    def extendMarkdown(self, md: "Markdown") -> None:
+        """Supports ~TEXT~ and ~~TEXT~~ syntax."""
+        md.inlinePatterns.register(
+            SimpleTagInlineProcessor(r"(\~{1,2})(.+?)\1", "del"), "tilde del", 170
         )

--- a/src/wagtailmarkdown/utils.py
+++ b/src/wagtailmarkdown/utils.py
@@ -8,7 +8,11 @@ from django.utils.encoding import smart_str
 from django.utils.safestring import mark_safe
 
 from wagtailmarkdown.constants import DEFAULT_BLEACH_KWARGS, SETTINGS_MODE_OVERRIDE
-from wagtailmarkdown.mdx.inlinepatterns import ImageExtension, LinkExtension
+from wagtailmarkdown.mdx.inlinepatterns import (
+    DelExtension,
+    ImageExtension,
+    LinkExtension,
+)
 from wagtailmarkdown.mdx.linker import LinkerExtension
 
 
@@ -91,6 +95,7 @@ def _get_default_markdown_kwargs():
             ),
             LinkExtension(),
             ImageExtension(),
+            DelExtension(),
         ],
         "extension_configs": {
             "codehilite": [

--- a/tests/testapp/tests/test_templatetags.py
+++ b/tests/testapp/tests/test_templatetags.py
@@ -270,3 +270,19 @@ class TestTemplateTags(TestCase):
             _options_to_dict("class=left,filter=fill-200x200,foo =bar,baz="),
             {"class": "left", "filter": "fill-200x200", "foo": "bar", "baz": ""},
         )
+
+    def test_del_extension(self):
+        self.assertEqual(markdown("~~removed~~"), "<p><del>removed</del></p>")
+        self.assertEqual(
+            markdown("pre~~removed~~post"), "<p>pre<del>removed</del>post</p>"
+        )
+        self.assertEqual(markdown("~removed~"), "<p><del>removed</del></p>")
+        self.assertEqual(
+            markdown("pre~removed~post"), "<p>pre<del>removed</del>post</p>"
+        )
+
+        self.assertEqual(
+            markdown("~~one~~~two~~~three~~"),
+            "<p><del>one</del><del>two</del><del>three</del></p>",
+        )
+        self.assertEqual(markdown("~~~weird~~~"), "<p><del>~weird</del>~</p>")

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 min_version = 4.22
 
 envlist =
-    py{39,310,311,312}-django42-wagtail{63,70,71}
-    py{310,311,312,313}-django{51,52}-wagtail{63,70,71}
+    py{39}-django42-wagtail{63}
+    py{310,311}-django{51}-wagtail{70}
+    py{312,313}-django{52}-wagtail{71}
 
 [gh-actions]
 python =


### PR DESCRIPTION
`~TEXT~` and `~~TEXT~~` result in `<del>TEXT</del>`