### PR TITLE
Add Wagtail 7.4 support; drop Wagtail 6.3

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -26,6 +26,6 @@ jobs:
           python-version: "3.14"
       - name: Install dependencies
         # keep in sync with .pre-commit-config.yaml
-        run: python -Im pip install ruff==0.15.8
+        run: python -Im pip install ruff==0.15.12
       - name: Run Ruff
         run: ruff check --output-format=github ./src/wagtailmarkdown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.8'  # keep in sync with .github/workflows/ruff.yml
+    rev: 'v0.15.12'  # keep in sync with .github/workflows/ruff.yml
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Updated minimum Python requirement to 3.10
 - Added Wagtail 7.3 and Python 3.14 to test matrix
 - Dropped Python 3.9 and Wagtail 7.1 from test matrix
+- Added Wagtail 7.1, 7.2 and 7.4 (LTS) to the test matrix
+- Added Django 6.0 to the test matrix
+- Dropped support for Wagtail 6.3 (active support ended 2026-05-01); minimum Wagtail is now 7.0
 
 ## [0.13.0] - 2025-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,19 @@
 
 ## [Unreleased]
 
+## Added
+
+- Added Wagtail 7.3, 7.4 (LTS) and Python 3.14 to test matrix
+- Added Django 6.0 to the test matrix
+
+## Removed
+
+- Dropped Python 3.9 and Wagtail 7.1, 7.2 from test matrix
+- Dropped support for Wagtail 6.3
+
 ## Changed
 
 - Updated minimum Python requirement to 3.10
-- Added Wagtail 7.3 and Python 3.14 to test matrix
-- Dropped Python 3.9 and Wagtail 7.1 from test matrix
-- Added Wagtail 7.1, 7.2 and 7.4 (LTS) to the test matrix
-- Added Django 6.0 to the test matrix
-- Dropped support for Wagtail 6.3 (active support ended 2026-05-01); minimum Wagtail is now 7.0
 
 ## [0.13.0] - 2025-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@
 
 ## Removed
 
-- Dropped Python 3.9 and Wagtail 7.1, 7.2 from test matrix
-- Dropped support for Wagtail 6.3
+- Dropped support for Python < 3.10, Django < 5.2, Wagtal < 7.0
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ## Added
 
-- Added Wagtail 7.3, 7.4 (LTS) and Python 3.14 to test matrix
-- Added Django 6.0 to the test matrix
+- Added Python 3.14, Django 6.0, Wagtail 7.3 and 7.4 (LTS) to the test matrix
 
 ## Removed
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ And render the content in a template:
 
 ## Compatibility
 
-wagtail-markdown supports Wagtail 5.2 and above, python-markdown 3.3 and above.
+wagtail-markdown supports Wagtail 7.0 and above, python-markdown 3.3 and above.
 
 ## Contributing
 
@@ -353,11 +353,11 @@ tox -p
 To run tests for a specific environment:
 
 ```shell
-tox -e py313-django5.2-wagtail7.0
+tox -e py313-django52-wagtail74
 ```
 
 or, a specific test
 
 ```shell
-tox -e py313-django5.2-wagtail7.0 -- tests.testapp.tests.test_admin.TestFieldsAdmin
+tox -e py313-django52-wagtail74 -- tests.testapp.tests.test_admin.TestFieldsAdmin
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,15 +23,15 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
 ]
 
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "Wagtail>=6.3",
+    "Wagtail>=7.0",
     "Markdown>=3.3,<4",
     # note: bleach5 requires bleach[css]. Will make one of the next versions require >= 5
     "bleach>=3.3,<5",

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 min_version = 4.22
 
 envlist =
-    py{310}-django42-wagtail{70}
-    py{311}-django52-wagtail{70}
-    py{312}-django52-wagtail{73}
+    py{310}-django52-wagtail{70}
+    py{311}-django52-wagtail{73}
     py{312,313,314}-django{52,60}-wagtail{74}
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,6 @@ setenv =
 extras = testing
 
 deps =
-    django42: Django>=4.2,<5.0
-    django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
     django60: Django>=6.0,<6.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,11 @@
 min_version = 4.22
 
 envlist =
-    py{310}-django42-wagtail{63}
-    py{310,311}-django{51}-wagtail{70}
-    py{312,313,314}-django{52}-wagtail{73}
+    py{310,311,312}-django42-wagtail{70,71,72,73}
+    py{310,311,312,313}-django51-wagtail{70,71,72}
+    py{310,311,312,313}-django52-wagtail{70,71}
+    py{310,311,312,313,314}-django52-wagtail{72,73,74}
+    py{312,313,314}-django60-wagtail{72,73,74}
 
 [gh-actions]
 python =
@@ -34,10 +36,13 @@ deps =
     django42: Django>=4.2,<5.0
     django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
 
-    wagtail63: wagtail>=6.3,<6.4
     wagtail70: wagtail>=7.0,<7.1
+    wagtail71: wagtail>=7.1,<7.2
+    wagtail72: wagtail>=7.2,<7.3
     wagtail73: wagtail>=7.3,<7.4
+    wagtail74: wagtail>=7.4,<7.5
 
 install_command = python -m pip install -U {opts} {packages}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,6 @@ deps =
     django60: Django>=6.0,<6.1
 
     wagtail70: wagtail>=7.0,<7.1
-    wagtail71: wagtail>=7.1,<7.2
-    wagtail72: wagtail>=7.2,<7.3
     wagtail73: wagtail>=7.3,<7.4
     wagtail74: wagtail>=7.4,<7.5
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,10 @@
 min_version = 4.22
 
 envlist =
-    py{310,311,312}-django42-wagtail{70,71,72,73}
-    py{310,311,312,313}-django51-wagtail{70,71,72}
-    py{310,311,312,313}-django52-wagtail{70,71}
-    py{310,311,312,313,314}-django52-wagtail{72,73,74}
-    py{312,313,314}-django60-wagtail{72,73,74}
+    py{310}-django42-wagtail{70}
+    py{311}-django52-wagtail{70}
+    py{312}-django52-wagtail{73}
+    py{312,313,314}-django{52,60}-wagtail{74}
 
 [gh-actions]
 python =


### PR DESCRIPTION
## Summary

- Bring the declared support range into line with Wagtail 7.4 LTS (released 2026-05-04) and drop Wagtail 6.3 LTS (active support ended 2026-05-01).
- New target range: Wagtail **7.0 → 7.4**, Django **4.2 / 5.1 / 5.2 / 6.0**, Python **3.10–3.14**.
- Django 6.0 added (supported by Wagtail ≥ 7.2); Django 4.2 and 5.1 retained because Wagtail 7.0–7.3 still support them.
- Minimum `Wagtail` dependency bumped to `>=7.0`. Wagtail 6 framework classifier removed.
- `tox.ini` envlist rebuilt to cover each valid Wagtail × Django × Python combination from the Wagtail compatibility table.
- README compatibility statement updated; CHANGELOG `Unreleased` entry added.
- Dev tooling: `ruff` bumped 0.15.8 → 0.15.12 in `.pre-commit-config.yaml` and `.github/workflows/ruff.yml` (kept in sync).
- No `wagtail.VERSION` / `django.VERSION` / `sys.version_info` guards exist in source — nothing to delete. No Wagtail 7.4 deprecated APIs (`AccessibilityItem`, `{% page_header_buttons %}`) are referenced.

## Test plan

- [ ] CI matrix runs green across the new envlist
- [ ] `tox -e py314-django60-wagtail74` (primary new combination)
- [ ] `tox -e py310-django42-wagtail70` (oldest supported combination)
- [ ] `tox -e py313-django52-wagtail73` (mid-range smoke)
- [ ] `pre-commit run --all-files` passes
- [ ] Manual smoke of the EasyMDE editor in a Wagtail 7.4 admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)